### PR TITLE
removed extra '^' which caused warning/error on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lit-element": "^2.3.1"
   },
   "peerDependencies": {
-    "@alaskaairux/orion-design-tokens": "^^2.12.1",
+    "@alaskaairux/orion-design-tokens": "^2.12.1",
     "@alaskaairux/orion-icons": "^2.0.4",
     "@alaskaairux/orion-web-core-style-sheets": "^2.10.2",
     "@webcomponents/webcomponentsjs": "^2.4.0",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Removed an extra '^' from the ods dependency in package.json

**Fixes:** # (issue, if applicable)
Issue not created, but prior to this PR, when installing auro-hyperlink, npm throws an error (and continues to work) that the package is not included. This reduces some noise. 

## Type of change:

Please delete options that are not relevant.

- [x] Minor bug fix

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
