### PR TITLE
feat: apply focus-visible polyfill to shadow root #55

### DIFF
--- a/demo/sass/style.scss
+++ b/demo/sass/style.scss
@@ -4,8 +4,8 @@
 @import "./node_modules/@alaskaairux/orion-design-tokens/dist/tokens/SassCustomProperties";
 
 // Import deprecated  Design Token variables
-@import "./node_modules/@alaskaairux/orion-design-tokens/dist/tokens/tokenVariables";
-@import "./node_modules/@alaskaairux/orion-design-tokens/dist/tokens/tokenProperties";
+@import "./node_modules/@alaskaairux/orion-design-tokens/dist/tokens/TokenVariables";
+@import "./node_modules/@alaskaairux/orion-design-tokens/dist/tokens/TokenProperties";
 
 // Import baseline library dependencies
 // Mixins

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -5,6 +5,7 @@
 
 import { LitElement, html } from "lit-element";
 import 'focus-visible/dist/focus-visible.min.js';
+import { isFocusVisibleSupported, isFocusVisiblePolyfillAvailable } from './util';
 
 // build the component class
 export default class ComponentBase extends LitElement {
@@ -24,6 +25,13 @@ export default class ComponentBase extends LitElement {
     this.addEventListener('touchstart', function() {
       this.classList.add('is-touching');
     });
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (!isFocusVisibleSupported() && isFocusVisiblePolyfillAvailable()) {
+      window.applyFocusVisiblePolyfill(this.shadowRoot);
+    }
   }
 
   // function to define props used within the scope of thie component

--- a/src/style.scss
+++ b/src/style.scss
@@ -21,13 +21,6 @@
 // Import tokens selectors
 @import "./node_modules/@alaskaairux/orion-icons/dist/icons";
 
-
-:host(.focus-visible) {
-  .hyperlink {
-    @include auro_focus-hyperlink(css);
-  }
-}
-
 // layout styles - define any layout specifications for UI that is contained WITHIN the component
 // never define layout that would cause effect on element ouside the scope of this component
 
@@ -41,6 +34,14 @@
 
   &:visited {
     color: var(--auro-color-ui-default-on-light);
+  }
+
+  &.focus-visible {
+    @include auro_focus-hyperlink(css);
+  }
+
+  &:focus-visible {
+    @include auro_focus-hyperlink(css);
   }
 
   @media (hover: hover) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,24 @@
+/**
+ * https://github.com/WICG/focus-visible#shadow-dom
+ * @returns {Boolean} whether the focus-visible polyfill is available
+ */
+const isFocusVisiblePolyfillAvailable = function() {
+  // eslint-disable-next-line
+  return window.applyFocusVisiblePolyfill != null;
+},
+
+
+/**
+ * @returns {Boolean} whether :focus-visible is supported
+ */
+isFocusVisibleSupported = function() {
+  try {
+    document.querySelector(':focus-visible');
+  } catch (error) {
+    return false;
+  }
+
+  return true;
+};
+
+export { isFocusVisiblePolyfillAvailable, isFocusVisibleSupported };


### PR DESCRIPTION
# Alaska Airlines Pull Request

Apply the focus-visible polyfill to the shadow root so that focus styles display when the element is in another shadow root.

Fixes #55

## Summary:

I used https://github.com/AlaskaAirlines/auro-button/pull/102 and https://github.com/AlaskaAirlines/auro-button/pull/118 as a reference implementation, plus a few changes to make eslint happy.

## Type of change:

Please delete options that are not relevant.

- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
