### PR TITLE
feat: add focus method

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -383,3 +383,43 @@ The `auro-icon` element comes with some pre-defined opinions, but these are easi
   <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>
+
+## Setting focus programmatically
+
+The following example illustrates a use case where a user may want to set a user's focus programmatically. I.e. through another click event.
+
+<auro-button onclick="getFocus()">click me for focus</auro-button>
+
+
+<!-- <div class="exampleWrapper">
+  <auro-hyperlink id="getFocus" href="https://www.alaskaair.com">Welcome to Alaska Airlines</auro-hyperlink>
+</div> -->
+
+<div class="exampleWrapper" style="display: flex; justify-content: space-between;">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./partials/focus.html) -->
+  <!-- The below content is automatically added from ./partials/focus.html -->
+  <auro-hyperlink id="getFocus" href="https://www.alaskaair.com">Welcome to Alaska Airlines</auro-hyperlink>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+  <!-- AURO-GENERATED-CONTENT:START (CODE:src=./util_focus.js) -->
+  <!-- The below code snippet is automatically added from ./util_focus.js -->
+  ```js
+  function getFocus() {
+    let el = document.getElementById("getFocus");
+    el.focus();
+  }
+  ```
+  <!-- AURO-GENERATED-CONTENT:END -->
+
+  <!-- AURO-GENERATED-CONTENT:START (CODE:src=./partials/focus.html) -->
+  <!-- The below code snippet is automatically added from ./partials/focus.html -->
+  ```html
+  <auro-hyperlink id="getFocus" href="https://www.alaskaair.com">Welcome to Alaska Airlines</auro-hyperlink>
+  ```
+  <!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>

--- a/demo/index.html
+++ b/demo/index.html
@@ -45,8 +45,10 @@
     <!-- If additional elements are needed for the demo, add them here. -->
     <script src="https://unpkg.com/@alaskaairux/auro-accordion@latest/dist/auro-accordion__bundled.js" type="module"></script>
     <script src="https://unpkg.com/@alaskaairux/auro-icon@latest/dist/auro-icon__bundled.js" type="module"></script>
+    <script src="https://unpkg.com/@alaskaairux/auro-button@latest/dist/auro-button__bundled.js" type="module"></script>
 
     <!-- This reference will need to be addressed with the demo wrapper of the hyperlink docsite page-->
     <script src="./util.js"></script>
+    <script src="./util_focus.js"></script>
   </body>
 </html>

--- a/demo/partials/focus.html
+++ b/demo/partials/focus.html
@@ -1,0 +1,1 @@
+<auro-hyperlink id="getFocus" href="https://www.alaskaair.com">Welcome to Alaska Airlines</auro-hyperlink>

--- a/demo/util_focus.js
+++ b/demo/util_focus.js
@@ -1,0 +1,4 @@
+function getFocus() {
+  let el = document.getElementById("getFocus");
+  el.focus();
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,3 +16,9 @@
 | `secondary`      | `secondary`      | `Boolean` | false   | Modifier for `type="cta"` secondary UI option.   |
 | `target`         | `target`         | `String`  |         | Specifies where to open the linked document.     |
 | `type`           | `type`           | `String`  |         | Enumerable attribute; [`nav`, `cta`]             |
+
+## Methods
+
+| Method  | Type       | Description         |
+|---------|------------|---------------------|
+| `focus` | `(): void` | Focus this element. |

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -223,6 +223,10 @@ export default class ComponentBase extends LitElement {
     return ariapressed;
   }
 
+  focus() {
+    this.shadowRoot.querySelector('a').focus();
+  }
+
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     return html`

--- a/src/component-base.js
+++ b/src/component-base.js
@@ -223,6 +223,7 @@ export default class ComponentBase extends LitElement {
     return ariapressed;
   }
 
+  /** Focus this element. */
   focus() {
     this.shadowRoot.querySelector('a').focus();
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -24,7 +24,7 @@
 // layout styles - define any layout specifications for UI that is contained WITHIN the component
 // never define layout that would cause effect on element outside the scope of this component
 
-/* stylelint-disable no-descending-specificity, selector-class-pattern, selector-max-class */
+/* stylelint-disable no-descending-specificity, selector-class-pattern, selector-max-class, declaration-no-important */
 
 :host {
   display: inline-block;
@@ -36,6 +36,13 @@
 
   color: var(--auro-color-ui-default-on-light);
   text-decoration: underline;
+
+  // applying a focus UI when using .focus()
+  &:focus {
+    @include auro_focus-hyperlink(css);
+
+    color: var(--auro-color-base-white) !important;
+  }
 
   &:visited {
     color: var(--auro-color-ui-default-on-light);
@@ -186,6 +193,6 @@ svg {
   --auro-size-lg: 1rem;
 
   position: relative;
-  top: 2px;
+  top: 4px;
   margin-left: var(--auro-size-xxxs);
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -24,10 +24,19 @@
 // layout styles - define any layout specifications for UI that is contained WITHIN the component
 // never define layout that would cause effect on element outside the scope of this component
 
-/* stylelint-disable no-descending-specificity, selector-class-pattern, selector-max-class, declaration-no-important */
+/* stylelint-disable no-descending-specificity, selector-class-pattern, selector-max-class */
 
 :host {
   display: inline-block;
+}
+
+// applying a focus UI when using .focus()
+:host([type='nav']) {
+  .hyperlink {
+    &:focus {
+      text-decoration: underline;
+    }
+  }
 }
 
 // component shape styles
@@ -39,9 +48,7 @@
 
   // applying a focus UI when using .focus()
   &:focus {
-    @include auro_focus-hyperlink(css);
-
-    color: var(--auro-color-base-white) !important;
+    text-decoration: none;
   }
 
   &:visited {

--- a/test/auro-hyperlink.test.js
+++ b/test/auro-hyperlink.test.js
@@ -128,6 +128,18 @@ describe('auro-hyperlink', () => {
     expect(anchor).to.have.attribute('referrerpolicy', 'strict-origin-when-cross-origin');
   });
 
+  it('allows programmatic focus', async () => {
+    const el = await fixture(html`
+      <auro-hyperlink href="https://www.apple.com" referrerpolicy target="_blank">It's Apple!</auro-hyperlink>
+    `);
+    const shadowLink = el.shadowRoot.querySelector('a');
+
+    el.focus();
+
+    expect(document.activeElement).to.equal(el);
+    expect(el.shadowRoot.activeElement).to.equal(shadowLink);
+  });
+
   it('auro-hyperlink custom element is defined', async () => {
     const el = await !!customElements.get("auro-hyperlink");
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #124

## Summary:

Adds a `focus` method to auro-hyperlink so that it's possible to do `document.querySelector('auro-hyperlink').focus()` without traversing the shadow root. This is the same implementation as auro-button.

The hyperlink's focus state will follow focus visible rules. If you are navigating with a keyboard when the hyperlink is programmatically focused, then the focus state will be visible. If you instead click to trigger the focus state, then the focus state will not be visible. 

### Navigating with keyboard and programmatically focusing the hyperlink (visible focus state)

See the below image -- the button is tabbed to with the keyboard and triggered with enter. The handler calls `focus` on the hyperlink, showing the focus state.

![hyperlink-focus](https://user-images.githubusercontent.com/4992896/157931837-3125f0da-7f17-49ab-997d-6f3dbaa64db2.gif)

## Type of change:

Please delete options that are not relevant.


- [x] New capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
