### PR TITLE
Update small CTA to adjust content alignment

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -19,7 +19,14 @@
 // layout styles - define any layout specifications for UI that is contained WITHIN the component
 // never define layout that would cause effect on element outside the scope of this component
 
-/* stylelint-disable no-descending-specificity, selector-class-pattern, selector-max-class, declaration-empty-line-before, order/properties-order */
+/* stylelint-disable
+  declaration-empty-line-before,
+  no-descending-specificity,
+  order/properties-order,
+  selector-class-pattern,
+  selector-max-class,
+  selector-max-combinators,
+  selector-max-compound-selectors */
 
 :host {
   display: inline-block;
@@ -109,7 +116,7 @@
     font-family: var(--ds-font-family-default, $ds-font-family-default);
     font-size: var(--ds-text-body-size-default, $ds-text-body-size-default);
     font-weight: var(--ds-text-body-default-weight, $ds-text-body-default-weight);
-    
+
     min-height: var(--ds-size-600, $ds-size-600);
     max-height: var(--ds-size-600, $ds-size-600);
 
@@ -212,16 +219,22 @@
 :host([small][type='cta']),
 :host([small='true'][type='cta']) {
   .hyperlink--cta {
+    display: flex;
+
     min-width: unset;
 
     min-height: 2.25rem;
     max-height: 2.25rem;
 
     padding: var(--ds-size-100, $ds-size-100) var(--ds-size-200, $ds-size-200);
-  
-    line-height: 1.3; // Arbitrary value to align the text vertically, matching auro-button 
-    
+
+    line-height: var(--ds-unitless-scale-140, $ds-unitless-scale-140);
+
     font-size: var(--ds-text-body-size-sm, $ds-text-body-size-sm);
+
+    svg {
+      top: unset;
+    }
   }
 }
 
@@ -230,6 +243,6 @@ svg {
   --auro-size-lg: 1rem;
 
   position: relative;
-  top: 4px;
+  top: 2px;
   margin-left: var(--ds-size-25, $ds-size-25);
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -243,6 +243,6 @@ svg {
   --auro-size-lg: 1rem;
 
   position: relative;
-  top: 2px;
+  top: var(--ds-size-25, $ds-size-25);
   margin-left: var(--ds-size-25, $ds-size-25);
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #191 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

There was mainly an issue with the placement of an icon within the small CTA use case. The update allows for easier management of the additional content.

A couple of stylelint rules were slightly adjusted to allow for new code without having to also do a code refactor to meet linting needs.

Changes to be committed:
modified:   .stylelintrc
modified:   src/style.scss

### Before

<img width="1098" alt="Screen Shot 2024-01-06 at 2 23 34 PM" src="https://github.com/AlaskaAirlines/auro-hyperlink/assets/181089/11742ab7-d648-4386-bdf7-4654ced4d489">


### After

<img width="812" alt="Screen Shot 2024-01-06 at 3 37 36 PM" src="https://github.com/AlaskaAirlines/auro-hyperlink/assets/181089/280f5059-b5a9-43d7-a7b2-6b2a54e290ab">


## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
