### PR TITLE
`auro migration` update all repos to use Auro WCSS 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-hyperlink",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-hyperlink",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19,7 +19,7 @@
         "@alaskaairux/icons": "^4.44.1",
         "@aurodesignsystem/design-tokens": "^4.13.0",
         "@aurodesignsystem/eslint-config": "^1.3.3",
-        "@aurodesignsystem/webcorestylesheets": "^5.1.2",
+        "@aurodesignsystem/webcorestylesheets": "^6.0.1",
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@eslint/eslintrc": "^3.2.0",
@@ -71,7 +71,7 @@
       "peerDependencies": {
         "@alaskaairux/icons": "^4.43.0",
         "@aurodesignsystem/design-tokens": "^4.9.2",
-        "@aurodesignsystem/webcorestylesheets": "^5.1.2"
+        "@aurodesignsystem/webcorestylesheets": "^6.0.1"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -303,18 +303,18 @@
       }
     },
     "node_modules/@aurodesignsystem/webcorestylesheets": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-5.1.2.tgz",
-      "integrity": "sha512-pokV/Mf83oOCac8jjFjqjaHxWoaMrakPVxgpdG6eVSd3Tj5EiMjb3DlYGzOpl57R+s026gJtqfwdAPoj23b3og==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/webcorestylesheets/-/webcorestylesheets-6.0.1.tgz",
+      "integrity": "sha512-Q+bD0zio8dRUjSgRFBeuHmV6mSfQuLVpF+obDC0XCDcD7mbzXqJjRM/vEexy7soX4R/lsu1fKcngolgtC3Nr4g==",
       "hasInstallScript": true,
       "dependencies": {
-        "chalk": "^5.3.0"
+        "chalk": "^5.4.1"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20 || ^22"
       },
       "peerDependencies": {
-        "@aurodesignsystem/design-tokens": "^4.1.1",
+        "@aurodesignsystem/design-tokens": "^4.9.1",
         "sass": "^1.42.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   "peerDependencies": {
     "@alaskaairux/icons": "^4.43.0",
     "@aurodesignsystem/design-tokens": "^4.9.2",
-    "@aurodesignsystem/webcorestylesheets": "^5.1.2"
+    "@aurodesignsystem/webcorestylesheets": "^6.0.1"
   },
   "devDependencies": {
     "@alaskaairux/icons": "^4.44.1",
     "@aurodesignsystem/design-tokens": "^4.13.0",
     "@aurodesignsystem/eslint-config": "^1.3.3",
-    "@aurodesignsystem/webcorestylesheets": "^5.1.2",
+    "@aurodesignsystem/webcorestylesheets": "^6.0.1",
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-cli#30

## Summary by Sourcery

Update Auro Webcore Stylesheets to v6 and Auro Design Tokens to v4.13.0.

Enhancements:
- Upgrade `@aurodesignsystem/webcorestylesheets` from v5.1.2 to v6.0.1.
- Upgrade `@aurodesignsystem/design-tokens` from v4.9.2 to v4.13.0 in peer dependencies and from v4.9.2 to v4.13.0 in dev dependencies.