### PR TITLE
fix: make cta width not to oveflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-hyperlink",
-  "version": "4.2.4",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-hyperlink",
-      "version": "4.2.4",
+      "version": "5.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/style.scss
+++ b/src/style.scss
@@ -37,9 +37,11 @@
 :host([fluid][type='cta']),
 :host([fluid='true'][type='cta']) {
   width: 100%;
+  box-sizing: border-box;
 
   .hyperlink--cta {
     width: 100%;
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

CTA width was bigger than 100% due to the side padding, setting the `box-sizing` to `border-box` to fit in the container
## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the CTA width was bigger than 100% due to side padding.