### PR TITLE
docs: improve docs by adding info about `type=cta`

### DIFF
--- a/apiExamples/typeCta-ondark.html
+++ b/apiExamples/typeCta-ondark.html
@@ -1,0 +1,9 @@
+<auro-hyperlink ondark type="cta" href="https://kagi.com/">
+  Primary
+</auro-hyperlink>
+<auro-hyperlink ondark type="cta" secondary href="https://kagi.com/">
+  Secondary
+</auro-hyperlink>
+<auro-hyperlink ondark type="cta" fluid href="https://kagi.com/">
+  Fluid
+</auro-hyperlink>

--- a/apiExamples/typeCta.html
+++ b/apiExamples/typeCta.html
@@ -1,0 +1,5 @@
+<auro-hyperlink type="cta" href="https://kagi.com/">Primary</auro-hyperlink>
+<auro-hyperlink type="cta" secondary href="https://kagi.com/">
+  Secondary
+</auro-hyperlink>
+<auro-hyperlink type="cta" fluid href="https://kagi.com/">Fluid</auro-hyperlink>

--- a/docs/partials/index.md
+++ b/docs/partials/index.md
@@ -94,6 +94,29 @@ Aside from the standard hyperlink use-case, the `auro-hyperlink` element is inte
 
 </auro-accordion>
 
+## Using type="cta"
+
+If you simply want your hyperlink to look like a button but still act like a hyperlink, you will want to use `type="cta"`, which will style the hyperlink like a button. Note that you can also utilize the props `fluid` to make the hyperlink `width: 100%`, and `secondary` to make it look like a seconday button. See examples below.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/typeCta.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<div class="exampleWrapper--ondark">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/typeCta-ondark.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/typeCta.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/typeCta-ondark.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
 ## Unsupported types
 
 Not all URL types are supported for security reasons. Two common types that are worth mentioning are `javaScript:` and `data:`.


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adding additional examples for when a Hyperlink should look like a button. 

I am creating this because I was confused by the current documentation and examples. By adding this section other will have a much easier time understanding the appropriate uses and how to implement them. 

## Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
