### PR TITLE
fix: make anchor to get focus on `focus()`

### DIFF
--- a/src/auro-hyperlink.js
+++ b/src/auro-hyperlink.js
@@ -3,6 +3,7 @@
 
 // ---------------------------------------------------------------------
 
+import { LitElement } from "lit";
 import { html } from 'lit/static-html.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -66,6 +67,13 @@ export class AuroHyperlink extends ComponentBase {
       colorCss,
       tokensCss
     ];
+  }
+
+  static get shadowRootOptions() {
+    return {
+      ...LitElement.shadowRootOptions,
+      delegatesFocus: true,
+    };
   }
 
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

fixes #271 
## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Modify the Auro Hyperlink component to improve focus handling by delegating focus in the shadow DOM

Bug Fixes:
- Ensure that the hyperlink can properly receive focus when interacted with

Enhancements:
- Add shadow root option to delegate focus for improved accessibility