### PR TITLE
feat: add a11y attribute projection for hyperlink and hyperlink CTA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-hyperlink",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-hyperlink",
-      "version": "6.0.3",
+      "version": "6.0.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/component-base.mjs
+++ b/src/component-base.mjs
@@ -93,14 +93,6 @@ export default class ComponentBase extends AuroElement {
       },
 
       /**
-       * DEPRECATED.
-       */
-      role: {
-        type: String,
-        reflect: true
-      },
-
-      /**
        * Defines where to open the linked document.
        */
       target: {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce automated accessibility attribute forwarding for hyperlink and hyperlink CTA components and remove the deprecated `role` property from the base component.

New Features:
- Forward all ARIA and accessibility attributes from AuroHyperlink host to its internal `<a>` and `<auro-hyperlink-button>` elements via attribute transport and cleanup logic.

Enhancements:
- Remove the deprecated `role` property from the ComponentBase class.