### PR TITLE
fix: convert attribute transporter to module import via rename to .mjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@aurodesignsystem/auro-hyperlink",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-hyperlink",
-      "version": "6.0.4",
+      "version": "6.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@alaskaairux/icons": "^5.6.0",
         "@aurodesignsystem/auro-button": "11.3.3",
         "@aurodesignsystem/auro-icon": "^8.1.4",
-        "@aurodesignsystem/auro-library": "^5.4.0",
+        "@aurodesignsystem/auro-library": "^5.5.2",
         "@aurodesignsystem/design-tokens": "^8.4.0",
         "@aurodesignsystem/webcorestylesheets": "10.0.3",
         "chalk": "^5.4.1",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.4.0.tgz",
-      "integrity": "sha512-CuivH8Kk5iOfdth/jGjLTQ95Ly/8N3htzdP9d2meIV6TRWI4Y7vBl9Ee5JTAY9cNiydHsCthbXFKX7lC6PWh3w==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.5.2.tgz",
+      "integrity": "sha512-Qt1qjNhXcPn23gRw4w+W2IB5sVvmixi5oxp19YmE1ZYsygI7J/0BWmXsX+DH8ZQi2OhpKyS3ddSGk7GrlY2TdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@alaskaairux/icons": "^5.6.0",
     "@aurodesignsystem/auro-button": "11.3.3",
     "@aurodesignsystem/auro-icon": "^8.1.4",
-    "@aurodesignsystem/auro-library": "^5.4.0",
+    "@aurodesignsystem/auro-library": "^5.5.2",
     "@aurodesignsystem/design-tokens": "^8.4.0",
     "@aurodesignsystem/webcorestylesheets": "10.0.3",
     "chalk": "^5.4.1",

--- a/src/auro-hyperlink.js
+++ b/src/auro-hyperlink.js
@@ -11,7 +11,7 @@ import ComponentBase from './component-base.mjs';
 
 import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
 import * as RuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
-import { transportAllA11yAttributes } from '@aurodesignsystem/auro-library/scripts/runtime/a11yTransporter/a11yTransporter.js';
+import { transportAllA11yAttributes } from '@aurodesignsystem/auro-library/scripts/runtime/a11yTransporter/a11yTransporter.mjs';
 
 import { AuroIcon } from '@aurodesignsystem/auro-icon/src/auro-icon.js';
 import iconVersion from './iconVersion.js';


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Convert attribute transporter to ES module by renaming its file extension to .mjs and updating imports, and bump the @aurodesignsystem/auro-library dependency

Enhancements:
- Rename attribute transporter file to .mjs and switch to ES module import syntax

Build:
- Update @aurodesignsystem/auro-library dependency to version 5.5.2