### PR TITLE
fix: remove reference to `space` #280

### DIFF
--- a/src/component-base.mjs
+++ b/src/component-base.mjs
@@ -412,7 +412,7 @@ export default class ComponentBase extends AuroElement {
       }
 
       if (event.type === 'keydown') {
-        if (event.code === 'Enter' || event.code === 'Space') {
+        if (event.code === 'Enter') {
           ariaPressedNode.ariaPressed = true;
         } else {
           ariaPressedNode.ariaPressed = false;


### PR DESCRIPTION
# Alaska Airlines Pull Request

This commit will remove the reference to `space` for keyboard options that will activate the aria-pressed state.
The spacebar is not an expected keyboard input for use with a hyperlink element.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Remove Space keycode check for activating aria-pressed state on keyboard events