### PR TITLE
fix: fixed for auro-hyperlink not being rendered when relative and ta…

### DIFF
--- a/src/auro-hyperlink.js
+++ b/src/auro-hyperlink.js
@@ -134,7 +134,7 @@ export class AuroHyperlink extends ComponentBase {
       referrerpolicy="${ifDefined(this.referrerpolicy ? this.defaultReferrerPolicy : undefined)}"
       role="${ifDefined(this.role === "button" ? this.role : undefined)}"
       ?download="${this.download}"
-      target="${ifDefined(this.target && this.includesDomain ? this.target : undefined)}"
+      target="${ifDefined(this.target && (this.includesDomain || this.isRelativeUrl(this.safeUri)) ? this.target : undefined)}"
       tabindex="${ifDefined(this.role === "button" ? "0" : undefined)}"
     >
       <slot></slot>

--- a/src/auro-hyperlink.js
+++ b/src/auro-hyperlink.js
@@ -134,7 +134,7 @@ export class AuroHyperlink extends ComponentBase {
       referrerpolicy="${ifDefined(this.referrerpolicy ? this.defaultReferrerPolicy : undefined)}"
       role="${ifDefined(this.role === "button" ? this.role : undefined)}"
       ?download="${this.download}"
-      target="${ifDefined(this.target && (this.includesDomain || this.isRelativeUrl(this.safeUri)) ? this.target : undefined)}"
+      target="${ifDefined(this.target && (this.includesDomain || this.relative) ? this.target : undefined)}"
       tabindex="${ifDefined(this.role === "button" ? "0" : undefined)}"
     >
       <slot></slot>

--- a/src/component-base.mjs
+++ b/src/component-base.mjs
@@ -255,7 +255,11 @@ export default class ComponentBase extends AuroElement {
           url.protocol = "https:";
           return url.href;
         }
-        return href.replace(/^[^:]+:/, "");
+        /**
+         * This regex checks if the provided href starts with http:, http:, ftp:, etc...
+         * Also checks if it has // if that matches it replaces it for just one /
+         */
+        return href.replace(/^(?:[^:]+:)?\/\/?/, "/");
     }
   }
 
@@ -277,24 +281,6 @@ export default class ComponentBase extends AuroElement {
     svg.setAttribute("slot", "svg");
 
     return html`<${this.iconTag} customColor customSvg part="targetIcon">${svg}</${this.iconTag}>`;
-  }
-
-  /**
-   * Checks if a given URL is a relative URL.
-   * 
-   * @example
-   * // Assuming url = '/path/to/resource
-   * this.isRelativeUrl(url); // Returns true
-   * 
-   * @example
-   * // Assuming url = 'https://example.com/resource
-   * this.isRelativeUrl(url); // Returns false
-   * 
-   * @param {string} url The URL to check 
-   * @returns {boolean} Returns true if the URL is relative and false otherwise.
-   */
-  isRelativeUrl(url) {
-   return /^(?!https?:\/\/)(?!\/\/)[^\s]+$/.test(url); 
   }
 
   /**
@@ -324,7 +310,7 @@ export default class ComponentBase extends AuroElement {
      */
     const isAlaskaAirDomain = (url) => {
       // Relative URLs are considered part of alaskaair.com domain
-      if(this.isRelativeUrl(url)) {
+      if(this.relative) {
         return true
       };
       

--- a/src/component-base.mjs
+++ b/src/component-base.mjs
@@ -280,6 +280,24 @@ export default class ComponentBase extends AuroElement {
   }
 
   /**
+   * Checks if a given URL is a relative URL.
+   * 
+   * @example
+   * // Assuming url = '/path/to/resource
+   * this.isRelativeUrl(url); // Returns true
+   * 
+   * @example
+   * // Assuming url = 'https://example.com/resource
+   * this.isRelativeUrl(url); // Returns false
+   * 
+   * @param {string} url The URL to check 
+   * @returns {boolean} Returns true if the URL is relative and false otherwise.
+   */
+  isRelativeUrl(url) {
+   return /^(?!https?:\/\/)(?!\/\/)[^\s]+$/.test(url); 
+  }
+
+  /**
    * Generates an icon HTML element based on the target attribute.
    *
    * @example
@@ -305,6 +323,11 @@ export default class ComponentBase extends AuroElement {
      * @returns {boolean} Returns true if the URL's domain is 'alaskaair.com' or one of its subdomains, otherwise false.
      */
     const isAlaskaAirDomain = (url) => {
+      // Relative URLs are considered part of alaskaair.com domain
+      if(this.isRelativeUrl(url)) {
+        return true
+      };
+      
       const urlObject = new URL(url);
       return urlObject.hostname.endsWith(".alaskaair.com");
     };


### PR DESCRIPTION
…rget='_blank' are set

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix auro-hyperlink support for relative URLs by normalizing hrefs properly and treating them as internal so target attributes are applied

Bug Fixes:
- Update href normalization regex to strip optional protocols and unify leading slashes for relative links
- Consider relative URLs as internal domain in isAlaskaAirDomain and allow target attribute when relative