### PR TITLE
Simplify hyperlink interaction and layout, update tests

### DIFF
--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -276,7 +276,7 @@ The `shape` attribute accepts three values: `rounded`, `pill`, or `circle`.
 
 ### Using role="button"
 
-Aside from the standard hyperlink use-case, the `auro-hyperlink` element is intended to be used for button situations as illustrated below. Assuming the role of button, `auro-hyperlink` also will track the `aria-pressed` state.
+Aside from the standard hyperlink use-case, the `auro-hyperlink` element is intended to be used for button situations as illustrated below.
 
 **Note:** Any `href` will be ignored when using `role="button"`. A click-event must be passed to the element as illustrated in the example below.
 

--- a/src/auro-hyperlink.js
+++ b/src/auro-hyperlink.js
@@ -131,7 +131,6 @@ export class AuroHyperlink extends ComponentBase {
     <a
       ${ref(this.hyperlinkRef)}
       part="link"
-      aria-pressed="${ifDefined(this.role === "button" ? this.ariaPressedState(this.ariapressed) : undefined)}"
       class="${classMap(classes)}"
       href="${ifDefined(this.role ? undefined : this.safeUri)}"
       .rel="${ifDefined(this.target || this.rel ? this.getRelType(this.target, this.rel) : undefined)}"

--- a/src/component-base.mjs
+++ b/src/component-base.mjs
@@ -393,65 +393,6 @@ export default class ComponentBase extends AuroElement {
     return undefined;
   }
 
-  /**
-   * Sets the ARIA pressed state based on user interactions.
-   *
-   * @example
-   * // Assuming ariaPressed = false and user performs a mousedown event
-   * this.ariaPressedState(ariaPressed); // Returns true
-   *
-   * @example
-   * // Assuming ariaPressed = true and user performs a mouseup event
-   * this.ariaPressedState(ariaPressed); // Returns false
-   *
-   * @example
-   * // Assuming ariaPressed = false and user performs a keydown event with 'Enter' or 'Space'
-   * this.ariaPressedState(ariaPressed); // Returns true
-   *
-   * @example
-   * // Assuming ariaPressed = true and user performs a keyup event
-   * this.ariaPressedState(ariaPressed); // Returns false
-   *
-   * @private
-   * @param {boolean} ariaPressed - The initial value of the ARIA pressed state.
-   * @returns {boolean} The updated ARIA pressed state.
-   */
-  ariaPressedState(ariaPressed) {
-    const ariaToggle = function (event) {
-      const ariaPressedNode = this.shadowRoot.querySelector("[aria-pressed]");
-      ariaPressedNode.setAttribute("aria-pressed", "false");
-
-      if (event.type === "mousedown") {
-        ariaPressedNode.ariaPressed = true;
-      } else {
-        ariaPressedNode.ariaPressed = false;
-      }
-
-      if (event.type === "keydown") {
-        if (event.code === "Enter") {
-          ariaPressedNode.ariaPressed = true;
-
-          if (
-            this.hyperlinkRef?.value &&
-            this.hyperlinkRef.value.role === "button"
-          ) {
-            this.click();
-          }
-        } else {
-          ariaPressedNode.ariaPressed = false;
-        }
-      }
-    };
-
-    // Add event listeners
-    this.addEventListener("mousedown", ariaToggle);
-    this.addEventListener("mouseup", ariaToggle);
-    this.addEventListener("keydown", ariaToggle);
-    this.addEventListener("keyup", ariaToggle);
-
-    return ariaPressed;
-  }
-
   // function renders HTML and CSS into the scope of the component
   render() {
     return this.getMarkup();

--- a/src/component-base.mjs
+++ b/src/component-base.mjs
@@ -59,11 +59,6 @@ export default class ComponentBase extends AuroElement {
     /**
      * @private
      */
-    this.ariapressed = "false";
-
-    /**
-     * @private
-     */
     this.tabIsActive = "false";
 
     /**

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -49,6 +49,11 @@
       outline-offset: var(--ds-size-25, vac.$ds-size-25);
     }
   }
+  
+  [auro-icon] {
+    position: relative;
+    top: 1px;
+  }
 }
 
 // component shape styles

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -39,7 +39,7 @@
 // apply focus outline to inline hyperlinks that aren't CTA, nav, or button
 :host(:not([type='cta']):not([type='nav'])) {
   .hyperlink{
-    display: inline-block;
+    display: flex;
     border-radius: 3px;
     outline-offset: unset;
     outline-style: solid;

--- a/test/auro-hyperlink.test.js
+++ b/test/auro-hyperlink.test.js
@@ -15,7 +15,6 @@ describe("auro-hyperlink", () => {
 
     expect(anchor).to.have.attribute("role", "button");
     expect(anchor).to.have.attribute("tabindex", "0");
-    expect(anchor).to.have.attribute("aria-pressed", "false");
     expect(anchor).to.have.class("hyperlink--button");
     expect(anchor).not.to.have.attribute("href");
   });

--- a/test/auro-hyperlink.test.js
+++ b/test/auro-hyperlink.test.js
@@ -26,11 +26,10 @@ describe("auro-hyperlink", () => {
     `);
 
     const anchor = el.shadowRoot.querySelector("a");
+    const regex = /^http:\/\/localhost:\d+\/auro$/;
+    const match = regex.test(anchor.href);
 
-    console.log(anchor.href);
-
-    expect(anchor).to.have.attribute("href", "http://localhost:8000/auro");
-    expect(anchor).not.to.have.attribute("href", "/auro");
+    expect(match).to.be.true;
   });
 
   it("auro-hyperlink href is absolute URL", async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-hyperlink/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adjust hyperlink layout and interaction behavior and update tests accordingly.

Bug Fixes:
- Resolve layout issues by changing inline hyperlink display to flex for non-CTA, non-nav types.
- Prevent test flakiness around generated absolute URLs by asserting via a port-agnostic regex match instead of a hardcoded URL string.

Enhancements:
- Remove unused ARIA pressed state handling from the base component and hyperlink markup to simplify interaction logic.

Tests:
- Update hyperlink button tests to align with removed aria-pressed behavior and new href assertion strategy.